### PR TITLE
Use conftest.py for setup of test data

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def test_data_dir():
     data_dir = Path(__file__).resolve().parent / 'data'
     return data_dir

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def test_data_dir():
+    data_dir = Path(__file__).resolve().parent / 'data'
+    return data_dir

--- a/tests/paths.py
+++ b/tests/paths.py
@@ -1,7 +1,0 @@
-from pathlib import Path
-
-TEST_DIR = Path(__file__).parents[0].absolute()
-
-
-def get_test_data_path():
-    return TEST_DIR / 'data'

--- a/tests/test_cmr.py
+++ b/tests/test_cmr.py
@@ -4,23 +4,20 @@ from s1_enumerator import duplicate_gunw_found
 from s1_enumerator.cmr import extract_secondary_date
 from shapely.geometry import shape
 
-from .paths import get_test_data_path
-
 
 def test_secondary_date():
     gunw_id = 'S1-GUNW-D-R-144-tops-20210710_20200703-140051-35745N_33766N-PP-12c6-v2_0_4'
     secondary_date_str = extract_secondary_date(gunw_id)
-    assert(secondary_date_str == '2020-07-03')
+    assert secondary_date_str == '2020-07-03'
 
 
-def test_duplicate_entry():
+def test_duplicate_entry(test_data_dir):
 
-    data_dir = get_test_data_path()
-    duplicate_entry_path = data_dir / 'duplicate_entry.json'
-    duplicate_entry = json.load(open(duplicate_entry_path, 'r'))
+    duplicate_entry_path = test_data_dir / 'duplicate_entry.json'
+    duplicate_entry = json.loads(duplicate_entry_path.read_text())
 
     # Convert Geojson to Shapely Geometry
     duplicate_entry['geometry'] = shape(duplicate_entry['geometry'])
 
     gunw_id = duplicate_gunw_found(duplicate_entry)
-    assert(gunw_id == 'S1-GUNW-D-R-144-tops-20210710_20200703-140051-35745N_33766N-PP-12c6-v2_0_4')
+    assert gunw_id == 'S1-GUNW-D-R-144-tops-20210710_20200703-140051-35745N_33766N-PP-12c6-v2_0_4'

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -5,17 +5,11 @@ import pytest
 from geopandas import testing
 from s1_enumerator import distill_all_pairs, enumerate_ifgs
 
-from .paths import get_test_data_path
-
-data_dir = get_test_data_path()
-enum_dir = data_dir / 'enum_data'
-aoi_dir = data_dir / 'aoi'
-
 
 @pytest.mark.parametrize("aoi_name", ['aleutian', 'turkey', 'haiti', 'los_padres_ca'])
 @pytest.mark.parametrize("enumeration_type", ['tile', 'path'])
-def test_enum_annual(enumeration_type, aoi_name):
-    aoi_path = aoi_dir / f'{aoi_name}.geojson'
+def test_enum_annual(test_data_dir, enumeration_type, aoi_name):
+    aoi_path = test_data_dir / 'aoi' / f'{aoi_name}.geojson'
     aoi_df = gpd.read_file(aoi_path)
     aoi_geo = aoi_df.geometry.values[0]
 
@@ -36,16 +30,15 @@ def test_enum_annual(enumeration_type, aoi_name):
     df_test.drop(columns=['reference', 'secondary'], inplace=True)
 
     data_filename = f'{aoi_name}_annual_{enumeration_type}.geojson'
-    df_from_data = gpd.read_file(enum_dir / data_filename)
-    testing.assert_geodataframe_equal(df_test,
-                                      df_from_data)
+    df_from_data = gpd.read_file(test_data_dir / 'enum_data' / data_filename)
+    testing.assert_geodataframe_equal(df_test, df_from_data)
 
 
 @pytest.mark.parametrize("enumeration_type", ['tile', 'path'])
 @pytest.mark.parametrize("aoi_name", ['los_padres_ca'])
 @pytest.mark.parametrize("months", [None, [7, 8]])
-def test_enum_annual_parameters(enumeration_type, aoi_name, months):
-    aoi_path = aoi_dir / f'{aoi_name}.geojson'
+def test_enum_annual_parameters(test_data_dir, enumeration_type, aoi_name, months):
+    aoi_path = test_data_dir / 'aoi' / f'{aoi_name}.geojson'
     aoi_df = gpd.read_file(aoi_path)
     aoi_geo = aoi_df.geometry.values[0]
 
@@ -70,6 +63,6 @@ def test_enum_annual_parameters(enumeration_type, aoi_name, months):
     fixed_month_str = '' if months is None else 'fixed_months_'
 
     data_filename = f'{aoi_name}_annual_{enumeration_type}_{fixed_month_str}137.geojson'
-    df_from_data = gpd.read_file(enum_dir / data_filename)
+    df_from_data = gpd.read_file(test_data_dir / 'enum_data' / data_filename)
     testing.assert_geodataframe_equal(df_test,
                                       df_from_data)

--- a/tests/test_gis.py
+++ b/tests/test_gis.py
@@ -3,12 +3,9 @@ import numpy as np
 from rasterio.crs import CRS
 from s1_enumerator.gis import get_intersection_area_km2
 
-from .paths import get_test_data_path
 
-
-def test_km2_intersection():
-    data_dir = get_test_data_path()
-    utm_dir = data_dir / 'utm_data'
+def test_km2_intersection(test_data_dir):
+    utm_dir = test_data_dir / 'utm_data'
 
     left_path = utm_dir / 'left.geojson'
     right_path = utm_dir / 'right.geojson'

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -6,25 +6,20 @@ from geopandas import testing
 from s1_enumerator import get_s1_coverage_tiles
 from s1_enumerator.stack import collect_coverage_tiles
 
-from .paths import get_test_data_path
 
 COLS = ['sceneName',
         'start_date_str',
         'pathNumber',
         'geometry']
 
-data_dir = get_test_data_path()
-coverage_data_dir = data_dir / 'coverage_data'
-aoi_dir = data_dir / 'aoi'
-
 
 @pytest.mark.parametrize("aoi_name", ['aleutian', 'turkey', 'haiti', 'los_padres_ca'])
 @pytest.mark.parametrize("min_date_per_path", [1, 2])
-def test_collect_tiles(aoi_name, min_date_per_path):
-    coverage_path = coverage_data_dir / f'{aoi_name}_at_least_{min_date_per_path}.geojson'
+def test_collect_tiles(test_data_dir, aoi_name, min_date_per_path):
+    coverage_path = test_data_dir / 'coverage_data' / f'{aoi_name}_at_least_{min_date_per_path}.geojson'
     df_coverage_tiles_data = gpd.read_file(coverage_path)
 
-    aoi_path = aoi_dir / f'{aoi_name}.geojson'
+    aoi_path = test_data_dir / 'aoi' / f'{aoi_name}.geojson'
     aoi_df = gpd.read_file(aoi_path)
     aoi_geo = aoi_df.geometry.values[0]
 
@@ -40,13 +35,13 @@ def test_collect_tiles(aoi_name, min_date_per_path):
 
 @pytest.mark.parametrize("aoi_name", ['aleutian', 'turkey', 'haiti', 'los_padres_ca'])
 @pytest.mark.parametrize("dates_per_path", [1, 2])
-def test_get_coverage_tiles(aoi_name, dates_per_path):
+def test_get_coverage_tiles(test_data_dir, aoi_name, dates_per_path):
 
-    coverage_data_dir = data_dir / 'coverage_data'
+    coverage_data_dir = test_data_dir / 'coverage_data'
     coverage_path_exactly = coverage_data_dir / f'{aoi_name}_exactly_{dates_per_path}.geojson'
     df_tiles_data = gpd.read_file(coverage_path_exactly)
 
-    aoi_path = aoi_dir / f'{aoi_name}.geojson'
+    aoi_path = test_data_dir / 'aoi' / f'{aoi_name}.geojson'
     aoi_df = gpd.read_file(aoi_path)
     aoi_geo = aoi_df.geometry.values[0]
 
@@ -59,8 +54,8 @@ def test_get_coverage_tiles(aoi_name, dates_per_path):
                                       df_tiles_data)
 
 
-def test_get_coverage_error_current_date():
-    aoi_path = aoi_dir / 'aleutian.geojson'
+def test_get_coverage_error_current_date(test_data_dir):
+    aoi_path = test_data_dir / 'aoi' / 'aleutian.geojson'
     aoi_df = gpd.read_file(aoi_path)
     aoi_geo = aoi_df.geometry.values[0]
 
@@ -71,8 +66,8 @@ def test_get_coverage_error_current_date():
                               n_dates_per_path=2)
 
 
-def test_get_coverage_error_too_many_dates():
-    aoi_path = aoi_dir / 'aleutian.geojson'
+def test_get_coverage_error_too_many_dates(test_data_dir):
+    aoi_path = test_data_dir / 'aoi' / 'aleutian.geojson'
     aoi_df = gpd.read_file(aoi_path)
     aoi_geo = aoi_df.geometry.values[0]
 


### PR DESCRIPTION
`conftest.py` is where you'd typically define fixtures for pytest:
https://docs.pytest.org/en/6.2.x/fixture.html
test/package import problems that can be caused by including an `__init__.py` in the tests directory:
https://docs.pytest.org/en/6.2.x/goodpractices.html#tests-outside-application-code

You could also take it a step farther and define fixtures for the subdirectories (e.g., `aoi`) or do the actual data setup (JSON loads and whatnot), passing in just the data needed for the tests.

This is also where you'd setup extra test CLI options, test discovery, etc. 