### PR TITLE
Increase default max_results for s1 query

### DIFF
--- a/s1_enumerator/stack.py
+++ b/s1_enumerator/stack.py
@@ -107,7 +107,7 @@ def get_s1_coverage_tiles(aoi: Polygon,
 
 def get_s1_stack_by_poly_and_path(geometry: Polygon,
                                   path_num: Union[int, str],
-                                  max_results: int = 1_000) -> gpd.GeoDataFrame:
+                                  max_results: int = 100_000) -> gpd.GeoDataFrame:
     results = asf.geo_search(platform=[asf.PLATFORM.SENTINEL1],
                              intersectsWith=geometry.wkt,
                              maxResults=max_results,


### PR DESCRIPTION
This is necessary to prevent queries from prematurely being cut off.

This is a complement to the latest changes to the deployment notebooks in this PR (https://github.com/ACCESS-Cloud-Based-InSAR/HyP3-ARIA-Orchestration/pull/3).