### PR TITLE
Add hyp3-sdk and update readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Initial release of s1-enumerator, a package for enumerating Sentinel-1 A/B pairs
 for interferograms:
  * `s1_enumerator`, a `pip` installable python package that runs the enumeration
+ * update installation instructions for consistency vis-a-vis other repos

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Also provides functions to check if a [`S1-GUNW`](https://asf.alaska.edu/data-se
 
 1. Clone this repo `git clone https://github.com/ACCESS-Cloud-Based-InSAR/s1-enumerator.git`
 2. Navigate with your terminal to the repo.
-3. Create a new environment and install requirements using `conda env update -n s1-enumerator --file environment.yml` (or use [`mamba`](https://github.com/mamba-org/mamba) to speed install up)
-4. Install the package from cloned repo using `pip install .`
+3. Create a new environment and install requirements using `conda env update --file environment.yml` (or use [`mamba`](https://github.com/mamba-org/mamba) to speed install up)
+4. Install the package from cloned repo using `python -m pip install -e .`
 
 Requires `asf_search`, `geopandas`, `rasterio`, `requests`, `tqdm`, and `hyp3-sdk`. See the `environment.yml`.
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ Also provides functions to check if a [`S1-GUNW`](https://asf.alaska.edu/data-se
 
 ## Install
 
-1. `conda env update -n s1-enumerator --file environment.yml` (or use [`mamba`](https://github.com/mamba-org/mamba) to speed install up)
-2. `pip install .`
+1. Clone this repo `git clone https://github.com/ACCESS-Cloud-Based-InSAR/s1-enumerator.git`
+2. Navigate with your terminal to the repo.
+3. Create a new environment and install requirements using `conda env update -n s1-enumerator --file environment.yml` (or use [`mamba`](https://github.com/mamba-org/mamba) to speed install up)
+4. Install the package from cloned repo using `pip install .`
 
 Requires `asf_search`, `geopandas`, `rasterio`, `requests`, `tqdm`, and `hyp3-sdk`. See the `environment.yml`.
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ Also provides functions to check if a [`S1-GUNW`](https://asf.alaska.edu/data-se
 
 ## Install
 
-`pip install .`
+1. `conda env update -n s1-enumerator --file environment.yml` (or use [`mamba`](https://github.com/mamba-org/mamba) to speed install up)
+2. `pip install .`
 
-Requires `asf_search`, `geopandas`, `rasterio`, `requests`, and `tqdm`. See the `environment.yml`.
+Requires `asf_search`, `geopandas`, `rasterio`, `requests`, `tqdm`, and `hyp3-sdk`. See the `environment.yml`.
 
 ## Usage
 

--- a/environment.yml
+++ b/environment.yml
@@ -26,4 +26,5 @@ dependencies:
   - tqdm
   - requests
   - asf_search
-
+  - pip:
+      - hyp3-sdk


### PR DESCRIPTION
This package is necessary for deployment, and is hence embedded into the env file to minimize on manual environment management (i.e. separate pip install calls)

Also, readme updated to reflect consistent environment management/update vis-a-vis other suites here.